### PR TITLE
Show external schemas

### DIFF
--- a/templates/css/style.styl
+++ b/templates/css/style.styl
@@ -409,7 +409,7 @@ embossed-bg()
   display: block
   color: #ccc
 
-  & > h1, & > h2, & > h3, & > h4, & > h5, & > h6, & > p, & > table, & > ul, & > ol, & > aside, & > dl
+  & > h1, & > h2, & > h3, & > h4, & > h5, & > h6, & > p, & > table, & > ul, & > ol, & > aside, & > dl, & > details
     padding: 0px $code-annotation-padding
 
   hr

--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -100,6 +100,14 @@
 <pre><code>{{ example.value | escape }}</code></pre>
 </div>
   {% endfor %}
+  {% if (body.schema) %}
+    <details>
+      <summary>Schema</summary>
+      <div class="languagebox">
+        <pre><code>{{ body.schema }}</code></pre>
+      </div>
+    </details>
+  {% endif %}
 {% endfor %}
 {% endif %}
 
@@ -126,6 +134,14 @@
 <pre><code>{{ example.value | escape }}</code></pre>
 </div>
       {% endfor %}
+      {% if (body.schema) %}
+          <details>
+            <summary>Schema</summary>
+            <div class="languagebox">
+              <pre><code>{{ body.schema }}</code></pre>
+            </div>
+          </details>
+      {% endif %}
     {% endfor %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This addresses raml2html/default-theme#7 and applies a similar fix to raml2html/default-theme#8

![raml-schema](https://user-images.githubusercontent.com/4867329/28277155-4d7bbe2e-6b19-11e7-9b86-5ebabc955683.gif)
