### PR TITLE
Additional Info rendering for Request and Response bodies

### DIFF
--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -100,6 +100,10 @@
 <blockquote><h3 class="toc-ignore">REQUEST BODY</h3></blockquote>
 {% for body in method.body %}
   {% for example in body.examples %}
+<h4 class="toc-ignore">{{ example.displayName }}</h4>
+    {% if (example.description) %}
+<p>{{ example.description }}</p>
+    {% endif %}
 <div class="languagebox {{ getLanguage(body.key) }}">
 <pre><code>{{ example.value | escape }}</code></pre>
 </div>
@@ -134,6 +138,10 @@
     <blockquote><h3 h3 class="toc-ignore">RESPONSE BODY</h3></blockquote>
     {% for body in response.body %}
       {% for example in body.examples %}
+<h4 class="toc-ignore">{{ example.displayName }}</h4>
+    {% if (example.description) %}
+<p>{{ example.description }}</p>
+    {% endif %}      
 <div class="languagebox {{ getLanguage(body.key) }}">
 <pre><code>{{ example.value | escape }}</code></pre>
 </div>


### PR DESCRIPTION
Show example `displayName` and `description`, if available, for request and response bodies.