### PR TITLE
Fix incomplete replacement of spaces in getSafeId

### DIFF
--- a/lib/stylus-globals.js
+++ b/lib/stylus-globals.js
@@ -9,7 +9,7 @@ const curlCommandBuilder = require('./curl-command-builder')
  */
 function getSafeId (id) {
   if (id === undefined) id = ''
-  return id.toLowerCase().replace(' ', '-')
+  return id.toLowerCase().replace(/ /g, '-')
 }
 
 /**

--- a/test/stylus-globals.test.js
+++ b/test/stylus-globals.test.js
@@ -418,8 +418,8 @@ describe('getSafeId', () => {
   })
 
   it('should return a string without spaces', () => {
-    const input = 'foo bar'
-    expect(getSafeId(input)).to.equal('foo-bar')
+    const input = 'foo bar foo'
+    expect(getSafeId(input)).to.equal('foo-bar-foo')
   })
 })
 


### PR DESCRIPTION
Currently, only the first space is replaced by a dash when HTML ids are generated by caling `getSafeId`.

Example, if the method display name is `Get all users`, we would create a *safe* id of `get-all users`.

This little fix makes sure we replace all the space: `get-all-users`.

