### PR TITLE
Response codes and descriptions

### DIFF
--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -59,16 +59,14 @@
 {% if (method.responses | length) != 0 %}
 <br/>
 <p><strong><em><big>Possible Responses</big></em></strong></p>
-<dl>
 {% for response in method.responses %}
-  <dt>{{ response.code }}</dt>
-  <dd>
-     {% markdown -%}
-        {{ response.description }}
-     {%- endmarkdown %}
-  </dd>
+  <p>
+    <strong>{{ response.code }}</strong>
+    {% markdown -%}
+      {{ response.description }}
+    {%- endmarkdown %}
+  </p>
 {% endfor %}
-</dl>
 {% endif %}
 </div>
 

--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -59,12 +59,16 @@
 {% if (method.responses | length) != 0 %}
 <br/>
 <p><strong><em><big>Possible Responses</big></em></strong></p>
-<p>
-  {%- set comma = joiner() -%}
-  {%- for response in method.responses -%}
-  {{ comma() }} {{ response.code }}
-  {%- endfor -%}
-</p>
+<dl>
+{% for response in method.responses %}
+  <dt>{{ response.code }}</dt>
+  <dd>
+     {% markdown -%}
+        {{ response.description}}
+     {%- endmarkdown %}
+  </dd>
+{% endfor %}
+</dl>
 {% endif %}
 </div>
 

--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -142,11 +142,11 @@
 {% endif %}
 
 {% for response in method.responses %}
-  {% if ((response.code == "200" or response.code == "201") and hasExamples(response.body)) %}
+  {% if ((response.code >= 200 and response.code < 300) and hasExamples(response.body)) %}
     <blockquote><h3 h3 class="toc-ignore">RESPONSE BODY</h3></blockquote>
     {% for body in response.body %}
       {% for example in body.examples %}
-<h4 class="toc-ignore">{{ example.displayName }}</h4>
+<h4 class="toc-ignore">{{ example.displayName }} <i>{{ response.code }}</i></h4>
     {% if (example.description) %}
 <p>
    {% markdown -%}

--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -64,7 +64,7 @@
   <dt>{{ response.code }}</dt>
   <dd>
      {% markdown -%}
-        {{ response.description}}
+        {{ response.description }}
      {%- endmarkdown %}
   </dd>
 {% endfor %}

--- a/templates/resource.nunjucks
+++ b/templates/resource.nunjucks
@@ -106,7 +106,11 @@
   {% for example in body.examples %}
 <h4 class="toc-ignore">{{ example.displayName }}</h4>
     {% if (example.description) %}
-<p>{{ example.description }}</p>
+<p>
+   {% markdown -%}
+      {{ example.description }}
+   {%- endmarkdown %}
+</p>
     {% endif %}
 <div class="languagebox {{ getLanguage(body.key) }}">
 <pre><code>{{ example.value | escape }}</code></pre>
@@ -144,7 +148,11 @@
       {% for example in body.examples %}
 <h4 class="toc-ignore">{{ example.displayName }}</h4>
     {% if (example.description) %}
-<p>{{ example.description }}</p>
+<p>
+   {% markdown -%}
+      {{ example.description }}
+   {%- endmarkdown %}
+</p>
     {% endif %}      
 <div class="languagebox {{ getLanguage(body.key) }}">
 <pre><code>{{ example.value | escape }}</code></pre>


### PR DESCRIPTION
I've made some changes regarding the description of response codes, requests and responses.
According to spec desciptions support markdown, but the template didn't.